### PR TITLE
feat: add cross-platform scan-look previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 
 # QuickScan PDF (Expo SDK 51, pinned deps)
 
-Fast, private document scanner that auto‑crops pages and exports clean, grayscale PDFs.
+Fast, private document scanner that auto‑crops pages and exports clean PDFs with a realistic scanned look.
+
+## Features
+
+- Live auto‑crop guide while lining up the camera
+- Cross-platform scanned-look previews that match the exported PDF
 
 - Node **18 or 20** required.
 - No config-plugins in app.json (prevents expo-print plugin errors).

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "quickscan-pdf",
     "scheme": "quickscanpdf",
     "version": "1.0.0",
-    "description": "QuickScan PDF – scan documents to clean, grayscale PDFs",
+    "description": "QuickScan PDF – scan documents with live auto-crop and realistic scanned-look previews for clean PDFs",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-status-bar": "2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
+        "react-native-color-matrix-image-filters": "^1.0.7",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "4.11.1"
       },
@@ -3905,6 +3906,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4418,6 +4429,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fbjs/node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asap": "~2.0.3"
       }
     },
     "node_modules/fill-range": {
@@ -6179,6 +6223,27 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -6899,6 +6964,17 @@
         }
       }
     },
+    "node_modules/react-native-color-matrix-image-filters": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-color-matrix-image-filters/-/react-native-color-matrix-image-filters-1.0.7.tgz",
+      "integrity": "sha512-7CTw0pqnXTCZOI+/4ELBYE6pC9zhPbbCIx4B1hnj0If/mWcSSwfij5dOgMZp/IWwUBwgDdp+TC7MilEoobKEYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "fbjs": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -7484,6 +7560,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8090,6 +8173,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8126,6 +8216,33 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/undici": {
@@ -8333,6 +8450,17 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/whatwg-url-without-unicode": {
       "version": "8.0.0-3",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
@@ -8346,6 +8474,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,21 +9,22 @@
     "ios": "expo run:ios",
     "web": "expo start --web"
   },
-  "description": "QuickScan PDF – fast document scanner and PDF exporter",
+  "description": "QuickScan PDF – fast auto-cropping document scanner with realistic scanned-look previews and PDF exporter",
   "dependencies": {
-    "expo": "53.0.22",
-    "react": "19.0.0",
-    "react-native": "0.79.5",
     "@react-navigation/native": "7.0.14",
     "@react-navigation/native-stack": "7.1.9",
-    "react-native-screens": "4.11.1",
-    "react-native-safe-area-context": "5.4.0",
-    "expo-status-bar": "2.2.3",
+    "expo": "53.0.22",
     "expo-camera": "16.1.11",
-    "expo-print": "14.1.4",
-    "expo-image-manipulator": "13.1.7",
     "expo-file-system": "18.1.11",
-    "expo-sharing": "13.1.5"
+    "expo-image-manipulator": "13.1.7",
+    "expo-print": "14.1.4",
+    "expo-sharing": "13.1.5",
+    "expo-status-bar": "2.2.3",
+    "react": "19.0.0",
+    "react-native": "0.79.5",
+    "react-native-color-matrix-image-filters": "^1.0.7",
+    "react-native-safe-area-context": "5.4.0",
+    "react-native-screens": "4.11.1"
   },
   "devDependencies": {
     "@types/react": "~19.0.10",

--- a/src/components/PageItem.tsx
+++ b/src/components/PageItem.tsx
@@ -1,1 +1,105 @@
-import React from 'react';import { View, Image, StyleSheet, Text, Pressable } from 'react-native';import { colors } from '../theme/colors';type Props={uri:string;index:number;onRotate:()=>void;onUp:()=>void;onDown:()=>void;onRemove:()=>void};export const PageItem:React.FC<Props>=({uri,index,onRotate,onUp,onDown,onRemove})=>(<View style={styles.container}><Image source={{uri}} style={styles.thumb}/><View style={{flex:1,marginLeft:12}}><Text style={styles.label}>Page {index+1}</Text><View style={styles.actions}><Pressable onPress={onRotate} style={styles.action}><Text style={styles.actionText}>Rotate ↻</Text></Pressable><Pressable onPress={onUp} style={styles.action}><Text style={styles.actionText}>Up ↑</Text></Pressable><Pressable onPress={onDown} style={styles.action}><Text style={styles.actionText}>Down ↓</Text></Pressable><Pressable onPress={onRemove} style={[styles.action,{borderColor:colors.danger}]}><Text style={[styles.actionText,{color:colors.danger}]}>Remove ✕</Text></Pressable></View></View></View>);const styles=StyleSheet.create({container:{flexDirection:'row',backgroundColor:colors.card,padding:10,borderRadius:12,marginBottom:10,borderWidth:1,borderColor:colors.border},thumb:{width:80,height:110,borderRadius:8,backgroundColor:'#000'},label:{color:colors.text,fontWeight:'700',marginBottom:8},actions:{flexDirection:'row',flexWrap:'wrap'},action:{paddingVertical:6,paddingHorizontal:10,borderRadius:8,borderWidth:1,borderColor:colors.border,marginRight:8,marginBottom:8},actionText:{color:colors.text,fontWeight:'600'}});
+import React from 'react';
+import {
+  View,
+  Image,
+  StyleSheet,
+  Text,
+  Pressable,
+  Platform,
+} from 'react-native';
+import type { ComponentType } from 'react';
+import { colors } from '../theme/colors';
+
+// Lazy-require native color filters so web builds don't try bundling them
+let Grayscale: ComponentType<any>, Contrast: ComponentType<any>, Brightness: ComponentType<any>;
+if (Platform.OS !== 'web') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  ({ Grayscale, Contrast, Brightness } = require('react-native-color-matrix-image-filters'));
+}
+
+type Props = {
+  uri: string;
+  index: number;
+  onRotate: () => void;
+  onUp: () => void;
+  onDown: () => void;
+  onRemove: () => void;
+};
+
+export const PageItem: React.FC<Props> = ({
+  uri,
+  index,
+  onRotate,
+  onUp,
+  onDown,
+  onRemove,
+}) => (
+  <View style={styles.container}>
+    {Platform.OS === 'web' ? (
+      <Image source={{ uri }} style={[styles.thumb, styles.webFilter]} />
+    ) : (
+      <Grayscale>
+        <Contrast value={1.15}>
+          <Brightness value={0.05}>
+            <Image source={{ uri }} style={styles.thumb} />
+          </Brightness>
+        </Contrast>
+      </Grayscale>
+    )}
+    <View style={styles.info}>
+      <Text style={styles.label}>Page {index + 1}</Text>
+      <View style={styles.actions}>
+        <Pressable onPress={onRotate} style={styles.action}>
+          <Text style={styles.actionText}>Rotate ↻</Text>
+        </Pressable>
+        <Pressable onPress={onUp} style={styles.action}>
+          <Text style={styles.actionText}>Up ↑</Text>
+        </Pressable>
+        <Pressable onPress={onDown} style={styles.action}>
+          <Text style={styles.actionText}>Down ↓</Text>
+        </Pressable>
+        <Pressable
+          onPress={onRemove}
+          style={[styles.action, { borderColor: colors.danger }]}
+        >
+          <Text style={[styles.actionText, { color: colors.danger }]}>Remove ✕</Text>
+        </Pressable>
+      </View>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    backgroundColor: colors.card,
+    padding: 10,
+    borderRadius: 12,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  thumb: {
+    width: 80,
+    height: 110,
+    borderRadius: 8,
+    backgroundColor: '#000',
+  },
+  webFilter: {
+    filter: 'grayscale(100%) contrast(1.15) brightness(1.05)',
+  } as any,
+  info: { flex: 1, marginLeft: 12 },
+  label: { color: colors.text, fontWeight: '700', marginBottom: 8 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap' },
+  action: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  actionText: { color: colors.text, fontWeight: '600' },
+});
+

--- a/src/screens/ScannerScreen.tsx
+++ b/src/screens/ScannerScreen.tsx
@@ -70,6 +70,10 @@ export default function ScannerScreen({ navigation }: any) {
           facing="back"
           autofocus="on"
         />
+        {/* Live overlay to show auto‑crop bounds */}
+        <View pointerEvents="none" style={styles.overlay}>
+          <View style={styles.cropGuide} />
+        </View>
       </View>
       <View style={styles.controls}>
         <Button title="Capture" onPress={takePicture} />
@@ -100,6 +104,23 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
   },
   camera: { flex: 1 },
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  cropGuide: {
+    borderWidth: 2,
+    borderColor: "rgba(255,255,255,0.8)",
+    width: "80%",
+    aspectRatio: 1 / 1.4142,
+    borderStyle: "dashed",
+    borderRadius: 8,
+  },
   controls: {
     padding: 16,
     borderTopWidth: 1,


### PR DESCRIPTION
## Summary
- render captured page thumbnails with color-matrix filters on iOS and Android
- keep CSS filter fallback for web and update SEO copy for new scan-look previews
- add react-native-color-matrix-image-filters dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ae4bd2d77c832986cd690698aa35f3